### PR TITLE
Update incubation.md

### DIFF
--- a/process/incubation.md
+++ b/process/incubation.md
@@ -76,7 +76,7 @@ All projects and their respective levels will be listsed on the Swift Server Eco
 
 The SSWG will meet every 6 month to review all projects and reserves the right to demote, archive, or remove projects that no longer fulfill minimal requirements. For example, a Graduated project that no longer receives regular updates or fails to address security concerns in timely fashion. Similarly, the SSWG reserves the right to remove or archive Pitches and Proposals that no longer receive updates.
 
-Changes to the Swift Server Ecosystem index page will announced by the SSWG using the Swift Server forums.
+Changes to the Swift Server Ecosystem index page will be announced by the SSWG using the Swift Server forums.
 
 ## Minimal Requirements
 

--- a/process/incubation.md
+++ b/process/incubation.md
@@ -128,9 +128,8 @@ Changes to the incubation process must be documented and published publicly and 
 
 * Major: Represents a deeper change in approach or workflow
 * Minor: Small change in concepts or nomenclature.
-* Patch: Trivial changes such as typos or formatting. 
 
-Non trivial updates (major and minor) require a supermajority vote from the SSWG.
+Updates resulting in a version bump require a supermajority vote from the SSWG. Trivial changes, such as typos or formatting adjustments, do not require a version bump. 
 
 ## Resources and References
 

--- a/process/incubation.md
+++ b/process/incubation.md
@@ -8,9 +8,9 @@ As described on https://swift.org/server/, the goal of the Swift Server Work Gro
 
 The difference between the SSWG and the Swift Evolution process is that server-oriented libraries and tools that are produced as a result of work group efforts will exist outside of the Swift language project itself and will be distributed across different code bases.
 
-The teams at Apple, IBM and Vapor have engineers that will actively participate in the development of such libraries and tools and we would love to see the community joining in this effort. To that end, the work group defined and launches an incubation process where anyone can pitch, propose, develop and contribute to such libraries and tools.
+The teams at Apple, IBM, and Vapor have engineers that will actively participate in the development of such libraries and tools and we would love to see the community joining in this effort. To that end, the work group defined and launches an incubation process where anyone can pitch, propose, develop, and contribute to such libraries and tools.
 
-The incubation process is designed to help nurture and mature projects ensuring standardization, quality and longevity. It also seeks to increase the visibility of ideas, experiments or other early work that can add value to the SSWG mission. The following document details this incubation process.
+The incubation process is designed to help nurture and mature projects ensuring standardization, quality and longevity. It also seeks to increase the visibility of ideas, experiments, or other early work that can add value to the SSWG mission. The following document details this incubation process.
 
 ## Process
 
@@ -18,7 +18,7 @@ Incubation is made of the following stages: **Pitch**, **Proposal**, **Developme
 
 ### Pitch
 
-Pitches are written proposals of new libraries or tools, including ideas for new features in existing libraries or tools. They are used to collect feedback from the community and help define the exact scope of a project prior to writing code. Pitches are submitted by creating a new thread in the Swift Server forum area.
+Pitches are written proposals of new libraries or tools including ideas for new features in existing libraries or tools. They are used to collect feedback from the community and help define the exact scope of a project prior to writing code. Pitches are submitted by creating a new thread in the Swift Server forum area.
 
 ### Proposal
 
@@ -43,7 +43,7 @@ The SSWG votes on pending proposals on a bi-weekly cadence, with the goal of vot
 
 ### Graduation Criteria
 
-Every SSWG project has an associated maturity level: **Sandbox**, **Incubating** or **Graduated**. Proposals should state their preferred initial maturity level and the SSWG will take a vote to decide on the actual level. 
+Every SSWG project has an associated maturity level: **Sandbox**, **Incubating**, or **Graduated**. Proposals should state their preferred initial maturity level and the SSWG will take a vote to decide on the actual level. 
 
 A **supermajority** (two-thirds) is required for a project to be accepted as Incubating or Graduated. If there is not a supermajority of votes to enter at the Graduated level, then the votes toward Graduated are recounted as votes to enter at the Incubating level. If there is not a supermajority of votes to enter at the Incubating level, then all votes are recounted as **sponsorship** to enter at the Sandbox level. If there are not at least two sponsors, the Proposal is rejected.
 

--- a/process/incubation.md
+++ b/process/incubation.md
@@ -129,7 +129,7 @@ Changes to the incubation process must be documented and published publicly and 
 * Major: Represents a deeper change in approach or workflow
 * Minor: Small change in concepts or nomenclature.
 
-Updates resulting in a version bump require a supermajority vote from the SSWG. Trivial changes, such as typos or formatting adjustments, do not require a version bump. 
+Updates resulting in a version bump require a supermajority vote from the SSWG. Trivial changes, such as fixing typos or formatting, do not require a version bump. 
 
 ## Resources and References
 

--- a/process/incubation.md
+++ b/process/incubation.md
@@ -1,7 +1,9 @@
 # Swift Server Work Group Incubation Process
+
 version 1.0
 
 ## Overview
+
 As described on https://swift.org/server/, the goal of the Swift Server Work Group (SSWG) is to create a robust, healthy ecosystem for server application development with Swift. One avenue to achieve this goal is to encourage the development of high quality, well maintained libraries and tools that the community can comfortably lean on.
 
 The difference between the SSWG and the Swift Evolution process is that server-oriented libraries and tools that are produced as a result of work group efforts will exist outside of the Swift language project itself, and will be distributed across different code bases.
@@ -11,18 +13,21 @@ The teams at Apple, IBM and Vapor have engineers that will actively participate 
 The incubation process is designed to help nurture and mature projects ensuring standardization, quality and longevity. It also seeks to increase the visibility of ideas, experiments or other early work that can add value to the SSWG mission. The following document details this incubation process.
 
 ## Process
-Incubation is made of the following stages: **Pitch**, **Proposal**, **Development** and **Recommendation**. The Development stage is where the majority of incubation take place. The SSWG will publicly publish a "Swift Server Ecosystem" index page where it will list it's recommended tools and libraries as well as the projects that are part of the incubation process and their respective incubation level.
+
+Incubation is made of the following stages: **Pitch**, **Proposal**, **Development** and **Recommendation**. The Development stage is where the majority of incubation take place. The SSWG will maintain a public "Swift Server Ecosystem" index page that will list all recommended tools and libraries as well as projects that are part of the incubation process and their respective incubation level.
 
 ### Pitch
-Written proposals of new libraries or tools, including ideas for new features in existing libraries or tools. Pitches are used to collect feedback from the community and help define the exact scope of the project prior to writing code. Pitches are submitted by creating a new thread in the Swift Server forum area.
+
+Pitches are written proposals of new libraries or tools, including ideas for new features in existing libraries or tools. They are used to collect feedback from the community and help define the exact scope of a project prior to writing code. Pitches are submitted by creating a new thread in the Swift Server forum area.
 
 ### Proposal
-For pitches to be moved into the Proposal stage, they must be endorsed by at least 2 members of the SSWG. The scope of the proposed code needs to closely align with the endorsed Pitch, and it is subject to review based on the SSWG graduation criteria defined below. Proposal are submitted by creating a new thread in the Swift Server forum area with a link to the code repository in question.  Proposals submitted to the SSWG must provide the following information:
+
+For a pitch to be moved into the Proposal stage, it must be endorsed by at least two members of the SSWG. The scope of the proposed code needs to closely align with the endorsed Pitch, and it is subject to review based on the SSWG graduation criteria defined below. Proposal are submitted by creating a new thread in the Swift Server forum area with a link to the code repository in question.  Proposals submitted to the SSWG must provide the following information:
 * Name (must be unique within SSWG)
 * Description (what it does, why it is valuable, origin and history)
 * Statement on alignment with SSWG mission
 * Preferred initial maturity level (see SSWG Graduation Criteria)
-* Sponsor (when applicable)
+* Sponsor (where applicable)
 * Initial committers (how long working on project)
 * Link to source (GitHub by default)
 * External dependencies (including licenses)
@@ -31,40 +36,47 @@ For pitches to be moved into the Proposal stage, they must be endorsed by at lea
 * Issue tracker (GitHub by default)
 * Communication channels (slack, irc, mailing lists)
 * Website (optional)
-* Social media accounts  (optional)
+* Social media accounts (optional)
 * Community size and any existing sponsorship
 
 The SSWG votes on pending proposals on a bi-weekly cadence, with the goal of voting on at least two proposals per month.
 
 ### Graduation Criteria
-Every SSWG project has an associated maturity level. Proposed SSWG projects should state their preferred initial maturity level, and the SSWG will take a vote to decide on the actual level. A two-thirds supermajority is required for a project to be accepted as incubating or graduated. If there is not a supermajority of votes to enter at the graduated level, then any graduated votes are recounted as votes to enter at the incubating level. If there is not a supermajority of votes to enter at the incubating level, then any graduated or incubating votes are recounted as sponsorship to enter at the sandbox level. If there is not enough sponsorship to enter as an sandbox level, the proposal is rejected.
+
+Every SSWG project has an associated maturity level: **Sandbox**, **Incubating** or **Graduated**. Proposals should state their preferred initial maturity level and the SSWG will take a vote to decide on the actual level. 
+
+A **supermajority** (two-thirds) is required for a project to be accepted as Incubating or Graduated. If there is not a supermajority of votes to enter at the Graduated level, then the votes toward Graduated are recounted as votes to enter at the Incubating level. If there is not a supermajority of votes to enter at the Incubating level, then all votes are recounted as **sponsorship** to enter at the Sandbox level. If there are not at least two sponsors, the Proposal is rejected.
 
 #### Sandbox Level
-To be accepted at the sandbox level a project must meet the [SSWG minimal requirements](#minimal-requirements) detailed below and be endorsed by at least 2 SSWG sponsors.
 
-Early adopters should treat early stage projects with extra care. While Sandbox projects are safe to try out, It is expected that some projects may fail and never move to the next maturity level and there is no guarantee of production readiness, users, or professional level support. As such users must exercise their own judgment.
+To be accepted at the Sandbox level, a project must meet the [SSWG minimal requirements](#minimal-requirements) detailed below and be endorsed by at least two SSWG sponsors.
+
+Early adopters should treat early stage projects with extra care. While Sandbox projects are safe to try out, it is expected that some projects may fail and never move to the next maturity level. There is no guarantee of production readiness, users, or professional level support. As such, users must exercise their own judgment.
 
 #### Incubating Level
-To be accepted at incubating level, a project must meet the sandbox level requirements plus:
+
+To be accepted at Incubating level, a project must meet the Sandbox level requirements plus:
+
 * Document that it is being used successfully in production by at least three independent end users which, in the SSWG judgement, are of adequate quality and scope.
 * Have a healthy number of committers.
 * Demonstrate a substantial ongoing flow of commits and merged contributions.
-* Receive a 2/3 vote from the SSWG to move to Incubation stage.
+* Receive a supermajority vote from the SSWG to move to Incubation stage.
 
-#### Graduation Level
-To graduate from sandbox or incubating level, or for a new project to join as a graduated project, a project must meet the incubating level criteria plus:
-* Adopt all [SSWG best practices](#best-practices), as details below.
+#### Graduated Level
+
+To be accepted at Graduated level, a project must meet the Incubating level criteria plus:
+
+* Adopt all [SSWG best practices](#best-practices), as detailed below.
 * Have committers from at least two organizations.
-* Receive a supermajority vote from the SSWG to move to graduation stage.
+* Receive a supermajority vote from the SSWG to move to Graduation stage.
 
 ### Recommended
-Projects that have successfully fulfilled the graduation requirements set forth by the SSWG, will be considered as "Recommended" and listed as such in Swift Server Ecosystem index page. In cases when more than one project solves a particular problem (eg two similar database drivers), they will all be listed ordered by popularity. That said, the SSWG reserves the right to define singular solution for critical building blocks, such as Logging or Metrics APIs, where consistency across the ecosystem is of a critical nature.
 
-The SSWG will meet every 6 month to review its Recommended projects list, and reserves the right to remove or archive projects that stops fulfilling the minimal requirements for that status, for example a project that no longer receives regular updates or fails to address security concerns in timely fashion. Similarly, the SSWG reserves the right to remove or archive Pitches and Proposals that become dated and do not receive updates for over 6 month.
+Projects that have successfully fulfilled the Graduated requirements receive Recommended status on the Swift Server Ecosystem index page. In cases where more than one project solves a particular problem (e.g., two similar database drivers), they will be ordered by popularity. The SSWG reserves the right to define a singular solution for critical building blocks, such as Logging or Metrics APIs, where consistency across the ecosystem is of a critical nature.
 
-Removal/archive decision requires a 2/3 vote from the SSWG. While projects can remain in an incubating state indefinitely, they are normally expected to graduate within one year.
+The SSWG will meet every 6 month to review all projects and reserves the right to demote, archive, or remove projects that no longer fulfill minimal requirements. For example, a Recommended project that no longer receives regular updates or fails to address security concerns in timely fashion. Similarly, the SSWG reserves the right to remove or archive Pitches and Proposals that no longer receive updates.
 
-Changes to the SSWG ecosystem index page will announced by the SSWG using the Swift Server forums.
+Changes to the Swift Server Ecosystem index page will announced by the SSWG using the Swift Server forums.
 
 ## Minimal Requirements
 
@@ -74,7 +86,7 @@ Changes to the SSWG ecosystem index page will announced by the SSWG using the Sw
   * [Developer Certificate of Origin](https://developercertificate.org) or a [Contributor License Agreement](https://en.wikipedia.org/wiki/Contributor_License_Agreement)
 * Ecosystem
   * Uses SwiftPM
-  * Integrated with critical SSWG ecosystem building blocks e.g. Logging and Metrics APIs, SwiftNIO for IO
+  * Integrated with critical SSWG ecosystem building blocks, e.g., Logging and Metrics APIs, SwiftNIO for IO
 * Concurrency / IO
   * Packages should be non-blocking (w/ async API) unless not possible (blocking C libs, etc)
   * There should be as little (preferably no) wrapping of NIO as possible. Exposing NIO types directly will go a long way for making packages compatible.
@@ -87,7 +99,7 @@ Changes to the SSWG ecosystem index page will announced by the SSWG using the Sw
   * Error handling
   * C wrapping vs native swift
   * Code style guidelines
-    * uses force unwraps and force tries only as preconditions, ie. conditions that the programmer regards as impossible or programmer error. All force tries/unwraps should come with a comment stating the reasons.
+  * Uses force unwraps and force tries only as preconditions, ie. conditions that the programmer regards as impossible or programmer error. All force tries/unwraps should come with a comment stating the reasons.
 * Longevity
   * Must be a team of 2+ developers
   * Must be from a team that has more than one public repository (or similar indication of experience)
@@ -96,7 +108,8 @@ Changes to the SSWG ecosystem index page will announced by the SSWG using the Sw
   * Apache 2
 
 ## Best Practices
-* CI setup across all supported swift and linux versions
+
+* CI setup across all supported Swift and Linux versions
 * Unit tests for both macOS and Linux
 * Use official docker (when appropriate)
 * Documented release methodology
@@ -106,12 +119,21 @@ Changes to the SSWG ecosystem index page will announced by the SSWG using the Sw
 
 
 ## Process Diagram
+
 ![process diagram](incubation.png)
 
 ## Change Management
-Changes to the incubation process must be documented and published publicly and are subject to semantic like versioning schema, in which a minor version increase represents a minor change in concepts or nomenclature, while a major version increase represents a deeper change in approach or workflow. Trivial changes such as typos or formatting do not require a version change. In addition to versioning, non trivial updates to the process require a 2/3 vote from the SSWG.
+
+Changes to the incubation process must be documented and published publicly and are subject to semantic versioning schema:
+
+* Major: Represents a deeper change in approach or workflow
+* Minor: Small change in concepts or nomenclature.
+* Patch: Trivial changes such as typos or formatting. 
+
+Non trivial updates (major and minor) require a supermajority vote from the SSWG.
 
 ## Resources and References
+
 * https://github.com/apple/swift-evolution
 * https://github.com/cncf/toc/tree/master/process
 * https://incubator.apache.org

--- a/process/incubation.md
+++ b/process/incubation.md
@@ -6,9 +6,9 @@ version 1.0
 
 As described on https://swift.org/server/, the goal of the Swift Server Work Group (SSWG) is to create a robust, healthy ecosystem for server application development with Swift. One avenue to achieve this goal is to encourage the development of high quality, well maintained libraries and tools that the community can comfortably lean on.
 
-The difference between the SSWG and the Swift Evolution process is that server-oriented libraries and tools that are produced as a result of work group efforts will exist outside of the Swift language project itself, and will be distributed across different code bases.
+The difference between the SSWG and the Swift Evolution process is that server-oriented libraries and tools that are produced as a result of work group efforts will exist outside of the Swift language project itself and will be distributed across different code bases.
 
-The teams at Apple, IBM and Vapor have engineers that will actively participate in the development of such libraries and tools, and we would love to see the community joining in this effort. To that end, the work group defined and launches an incubation process where anyone can pitch, propose, develop and contribute to such libraries and tools.
+The teams at Apple, IBM and Vapor have engineers that will actively participate in the development of such libraries and tools and we would love to see the community joining in this effort. To that end, the work group defined and launches an incubation process where anyone can pitch, propose, develop and contribute to such libraries and tools.
 
 The incubation process is designed to help nurture and mature projects ensuring standardization, quality and longevity. It also seeks to increase the visibility of ideas, experiments or other early work that can add value to the SSWG mission. The following document details this incubation process.
 
@@ -22,7 +22,7 @@ Pitches are written proposals of new libraries or tools, including ideas for new
 
 ### Proposal
 
-For a pitch to be moved into the Proposal stage, it must be endorsed by at least two members of the SSWG. The scope of the proposed code needs to closely align with the endorsed Pitch, and it is subject to review based on the SSWG graduation criteria defined below. Proposal are submitted by creating a new thread in the Swift Server forum area with a link to the code repository in question.  Proposals submitted to the SSWG must provide the following information:
+For a pitch to be moved into the Proposal stage, it must be endorsed by at least two members of the SSWG. The scope of the proposed code needs to closely align with the endorsed Pitch and it is subject to review based on the SSWG graduation criteria defined below. Proposal are submitted by creating a new thread in the Swift Server forum area with a link to the code repository in question.  Proposals submitted to the SSWG must provide the following information:
 * Name (must be unique within SSWG)
 * Description (what it does, why it is valuable, origin and history)
 * Statement on alignment with SSWG mission
@@ -51,7 +51,7 @@ A **supermajority** (two-thirds) is required for a project to be accepted as Inc
 
 To be accepted at the Sandbox level, a project must meet the [SSWG minimal requirements](#minimal-requirements) detailed below and be endorsed by at least two SSWG sponsors.
 
-Early adopters should treat early stage projects with extra care. While Sandbox projects are safe to try out, it is expected that some projects may fail and never move to the next maturity level. There is no guarantee of production readiness, users, or professional level support. As such, users must exercise their own judgment.
+Early adopters should treat early stage projects with extra care. While Sandbox projects are safe to try out, it is expected that some projects may fail and never move to the next maturity level. There is no guarantee of production readiness, users or professional level support. As such, users must exercise their own judgment.
 
 #### Incubating Level
 
@@ -74,7 +74,7 @@ To be accepted at Graduated level, a project must meet the Incubating level crit
 
 All projects and their respective levels will be listsed on the Swift Server Ecosystem index page. In cases where more than one project solves a particular problem (e.g., two similar database drivers), they will be ordered by popularity. The SSWG reserves the right to define a singular solution for critical building blocks, such as Logging or Metrics APIs, where consistency across the ecosystem is of a critical nature.
 
-The SSWG will meet every 6 month to review all projects and reserves the right to demote, archive, or remove projects that no longer fulfill minimal requirements. For example, a Graduated project that no longer receives regular updates or fails to address security concerns in timely fashion. Similarly, the SSWG reserves the right to remove or archive Pitches and Proposals that no longer receive updates.
+The SSWG will meet every 6 month to review all projects and reserves the right to demote, archive or remove projects that no longer fulfill minimal requirements. For example, a Graduated project that no longer receives regular updates or fails to address security concerns in timely fashion. Similarly, the SSWG reserves the right to remove or archive Pitches and Proposals that no longer receive updates.
 
 Changes to the Swift Server Ecosystem index page will be announced by the SSWG using the Swift Server forums.
 

--- a/process/incubation.md
+++ b/process/incubation.md
@@ -24,7 +24,7 @@ Pitches are written proposals of new libraries or tools, including ideas for new
 
 For a pitch to be moved into the Proposal stage, it must be endorsed by at least two members of the SSWG. The scope of the proposed code needs to closely align with the endorsed Pitch and it is subject to review based on the SSWG graduation criteria defined below. Proposal are submitted by creating a new thread in the Swift Server forum area with a link to the code repository in question.  Proposals submitted to the SSWG must provide the following information:
 * Name (must be unique within SSWG)
-* Description (what it does, why it is valuable, origin and history)
+* Description (what it does, why it is valuable, origin, and history)
 * Statement on alignment with SSWG mission
 * Preferred initial maturity level (see SSWG Graduation Criteria)
 * Sponsor (where applicable)
@@ -51,7 +51,7 @@ A **supermajority** (two-thirds) is required for a project to be accepted as Inc
 
 To be accepted at the Sandbox level, a project must meet the [SSWG minimal requirements](#minimal-requirements) detailed below and be endorsed by at least two SSWG sponsors.
 
-Early adopters should treat early stage projects with extra care. While Sandbox projects are safe to try out, it is expected that some projects may fail and never move to the next maturity level. There is no guarantee of production readiness, users or professional level support. As such, users must exercise their own judgment.
+Early adopters should treat early stage projects with extra care. While Sandbox projects are safe to try out, it is expected that some projects may fail and never move to the next maturity level. There is no guarantee of production readiness, users, or professional level support. As such, users must exercise their own judgment.
 
 #### Incubating Level
 
@@ -74,7 +74,7 @@ To be accepted at Graduated level, a project must meet the Incubating level crit
 
 All projects and their respective levels will be listsed on the Swift Server Ecosystem index page. In cases where more than one project solves a particular problem (e.g., two similar database drivers), they will be ordered by popularity. The SSWG reserves the right to define a singular solution for critical building blocks, such as Logging or Metrics APIs, where consistency across the ecosystem is of a critical nature.
 
-The SSWG will meet every 6 month to review all projects and reserves the right to demote, archive or remove projects that no longer fulfill minimal requirements. For example, a Graduated project that no longer receives regular updates or fails to address security concerns in timely fashion. Similarly, the SSWG reserves the right to remove or archive Pitches and Proposals that no longer receive updates.
+The SSWG will meet every 6 month to review all projects and reserves the right to demote, archive, or remove projects that no longer fulfill minimal requirements. For example, a Graduated project that no longer receives regular updates or fails to address security concerns in timely fashion. Similarly, the SSWG reserves the right to remove or archive Pitches and Proposals that no longer receive updates.
 
 Changes to the Swift Server Ecosystem index page will be announced by the SSWG using the Swift Server forums.
 

--- a/process/incubation.md
+++ b/process/incubation.md
@@ -8,7 +8,7 @@ As described on https://swift.org/server/, the goal of the Swift Server Work Gro
 
 The difference between the SSWG and the Swift Evolution process is that server-oriented libraries and tools that are produced as a result of work group efforts will exist outside of the Swift language project itself, and they will be distributed across different code bases.
 
-The teams at Apple, IBM, and Vapor have engineers that will actively participate in the development of such libraries and tools and we would love to see the community joining in this effort. To that end, the work group defined and launches an incubation process where anyone can pitch, propose, develop, and contribute to such libraries and tools.
+The teams at Apple, IBM, and Vapor have engineers that will actively participate in the development of such libraries and tools, and we would love to see the community joining in this effort. To that end, the work group defined and launches an incubation process where anyone can pitch, propose, develop, and contribute to such libraries and tools.
 
 The incubation process is designed to help nurture and mature projects ensuring standardization, quality, and longevity. It also seeks to increase the visibility of ideas, experiments, or other early work that can add value to the SSWG mission. The following document details this incubation process.
 
@@ -43,7 +43,7 @@ The SSWG votes on pending proposals on a bi-weekly cadence, with the goal of vot
 
 ### Graduation Criteria
 
-Every SSWG project has an associated maturity level: **Sandbox**, **Incubating**, or **Graduated**. Proposals should state their preferred initial maturity level and the SSWG will take a vote to decide on the actual level. 
+Every SSWG project has an associated maturity level: **Sandbox**, **Incubating**, or **Graduated**. Proposals should state their preferred initial maturity level, and the SSWG will take a vote to decide on the actual level. 
 
 A **supermajority** (two-thirds) is required for a project to be accepted as Incubating or Graduated. If there is not a supermajority of votes to enter at the Graduated level, then the votes toward Graduated are recounted as votes to enter at the Incubating level. If there is not a supermajority of votes to enter at the Incubating level, then all votes are recounted as **sponsorship** to enter at the Sandbox level. If there are not at least two sponsors, the Proposal is rejected.
 
@@ -124,7 +124,7 @@ Changes to the Swift Server Ecosystem index page will be announced by the SSWG u
 
 ## Change Management
 
-Changes to the incubation process must be documented and published publicly, and they are subject to semantic versioning schema:
+Changes to the incubation process must be documented and published publicly and are subject to semantic versioning schema:
 
 * Major: Represents a deeper change in approach or workflow
 * Minor: Small change in concepts or nomenclature.

--- a/process/incubation.md
+++ b/process/incubation.md
@@ -70,11 +70,11 @@ To be accepted at Graduated level, a project must meet the Incubating level crit
 * Have committers from at least two organizations.
 * Receive a supermajority vote from the SSWG to move to Graduation stage.
 
-### Recommended
+### Ecosystem Index
 
-Projects that have successfully fulfilled the Graduated requirements receive Recommended status on the Swift Server Ecosystem index page. In cases where more than one project solves a particular problem (e.g., two similar database drivers), they will be ordered by popularity. The SSWG reserves the right to define a singular solution for critical building blocks, such as Logging or Metrics APIs, where consistency across the ecosystem is of a critical nature.
+All projects and their respective levels will be listsed on the Swift Server Ecosystem index page. In cases where more than one project solves a particular problem (e.g., two similar database drivers), they will be ordered by popularity. The SSWG reserves the right to define a singular solution for critical building blocks, such as Logging or Metrics APIs, where consistency across the ecosystem is of a critical nature.
 
-The SSWG will meet every 6 month to review all projects and reserves the right to demote, archive, or remove projects that no longer fulfill minimal requirements. For example, a Recommended project that no longer receives regular updates or fails to address security concerns in timely fashion. Similarly, the SSWG reserves the right to remove or archive Pitches and Proposals that no longer receive updates.
+The SSWG will meet every 6 month to review all projects and reserves the right to demote, archive, or remove projects that no longer fulfill minimal requirements. For example, a Graduated project that no longer receives regular updates or fails to address security concerns in timely fashion. Similarly, the SSWG reserves the right to remove or archive Pitches and Proposals that no longer receive updates.
 
 Changes to the Swift Server Ecosystem index page will announced by the SSWG using the Swift Server forums.
 

--- a/process/incubation.md
+++ b/process/incubation.md
@@ -6,15 +6,15 @@ version 1.0
 
 As described on https://swift.org/server/, the goal of the Swift Server Work Group (SSWG) is to create a robust, healthy ecosystem for server application development with Swift. One avenue to achieve this goal is to encourage the development of high quality, well maintained libraries and tools that the community can comfortably lean on.
 
-The difference between the SSWG and the Swift Evolution process is that server-oriented libraries and tools that are produced as a result of work group efforts will exist outside of the Swift language project itself and will be distributed across different code bases.
+The difference between the SSWG and the Swift Evolution process is that server-oriented libraries and tools that are produced as a result of work group efforts will exist outside of the Swift language project itself, and they will be distributed across different code bases.
 
 The teams at Apple, IBM, and Vapor have engineers that will actively participate in the development of such libraries and tools and we would love to see the community joining in this effort. To that end, the work group defined and launches an incubation process where anyone can pitch, propose, develop, and contribute to such libraries and tools.
 
-The incubation process is designed to help nurture and mature projects ensuring standardization, quality and longevity. It also seeks to increase the visibility of ideas, experiments, or other early work that can add value to the SSWG mission. The following document details this incubation process.
+The incubation process is designed to help nurture and mature projects ensuring standardization, quality, and longevity. It also seeks to increase the visibility of ideas, experiments, or other early work that can add value to the SSWG mission. The following document details this incubation process.
 
 ## Process
 
-Incubation is made of the following stages: **Pitch**, **Proposal**, **Development** and **Recommendation**. The Development stage is where the majority of incubation take place. The SSWG will maintain a public "Swift Server Ecosystem" index page that will list all recommended tools and libraries as well as projects that are part of the incubation process and their respective incubation level.
+Incubation is made of the following stages: **Pitch**, **Proposal**, **Development**, and **Recommendation**. The Development stage is where the majority of incubation take place. The SSWG will maintain a public "Swift Server Ecosystem" index page that will list all recommended tools and libraries as well as projects that are part of the incubation process and their respective incubation level.
 
 ### Pitch
 
@@ -74,7 +74,7 @@ To be accepted at Graduated level, a project must meet the Incubating level crit
 
 All projects and their respective levels will be listsed on the Swift Server Ecosystem index page. In cases where more than one project solves a particular problem (e.g., two similar database drivers), they will be ordered by popularity. The SSWG reserves the right to define a singular solution for critical building blocks, such as Logging or Metrics APIs, where consistency across the ecosystem is of a critical nature.
 
-The SSWG will meet every 6 month to review all projects and reserves the right to demote, archive, or remove projects that no longer fulfill minimal requirements. For example, a Graduated project that no longer receives regular updates or fails to address security concerns in timely fashion. Similarly, the SSWG reserves the right to remove or archive Pitches and Proposals that no longer receive updates.
+The SSWG will meet every 6 month to review all projects, and it reserves the right to demote, archive, or remove projects that no longer fulfill minimal requirements. For example, a Graduated project that no longer receives regular updates or fails to address security concerns in timely fashion. Similarly, the SSWG reserves the right to remove or archive Pitches and Proposals that no longer receive updates.
 
 Changes to the Swift Server Ecosystem index page will be announced by the SSWG using the Swift Server forums.
 
@@ -124,7 +124,7 @@ Changes to the Swift Server Ecosystem index page will be announced by the SSWG u
 
 ## Change Management
 
-Changes to the incubation process must be documented and published publicly and are subject to semantic versioning schema:
+Changes to the incubation process must be documented and published publicly, and they are subject to semantic versioning schema:
 
 * Major: Represents a deeper change in approach or workflow
 * Minor: Small change in concepts or nomenclature.


### PR DESCRIPTION
This contains mostly grammar stuff and markdown formatting stuff:

- Consistent use of "supermajority" as name for two-thirds vote.
- Consistent capitalization of levels and stages.
- Rewrote some sentences to make them more clear.
- Consistent spacing in the markdown file. 

There are also a couple of slightly bigger changes that I am happy to remove if you like:

- Remove references to a separate "Recommended" status. This was a bit confusing as it wasn't entirely clear what the difference between Graduated / Recommended was. Could a Graduated project ever have it's Recommended status revoked? I think it's better if we just use Recommended as a synonym for Graduated. 
- _all_ project levels can be demoted, archived, or removed. I fear the incubating list will collect too much cruft if we say that projects can remain there indefinitely. If we look at the CNCF, we can see their list of incubating projects are all definitely active and up to date (https://www.cncf.io/projects/). 
- Trivial changes to the document should be patch semver, but not require a vote. 