### PR TITLE
add section about security requirements

### DIFF
--- a/process/incubation.md
+++ b/process/incubation.md
@@ -133,7 +133,9 @@ Changes to the Swift Server Ecosystem index page will be announced by the SSWG u
 
 ## Security Best Practices
 
-Project authors that discover, or been advised of vulnerabilities in their projects, must report them to the SSWG within 10d. Graduated projects are expected to address vulnerabilities within 30d. Reports should be sent to the SSWG using [Swift forums](https://forums.swift.org/c/server/security-updates). 
+Project authors that discover, or been advised of vulnerabilities in their projects, must report them to the SSWG within 10d. Graduated projects are expected to address vulnerabilities within 30d. Reports should be sent to the SSWG using [Swift forums](https://forums.swift.org/c/server/security-updates).
+
+Failure to report or address vulnerabilities may result in the SSWG publishing a security advisory, and could lead to retracting the project's status and listing it under the non-recommended projects list. In some cases, the SSWG may choose to find a technical contributor that can help resolve the security issues to minimize the impsct on the ecosystem. SSWG actions will be decided on a case by case basis and requuire a supermajority vote.
 
 The SSWG will publicly share a list of vulnerabilities and fixes on [Swift forums](https://forums.swift.org/c/server/security-updates) to inform the Swift Server user community. Members are encouraged to subscribe to notifications and adopt fixes as soon as possible.
 

--- a/process/incubation.md
+++ b/process/incubation.md
@@ -133,11 +133,11 @@ Changes to the Swift Server Ecosystem index page will be announced by the SSWG u
 
 ## Security Best Practices
 
-Project authors that discover, or been adviced of volnerabilities in their libraries, must report them to the SSWG within 10d. Graduated libraries are expected to address volnerabilities within 30d.
+Project authors that discover, or been advised of vulnerabilities in their libraries, must report them to the SSWG within 10d. Graduated libraries are expected to address vulnerabilities within 30d.
 
-The SSWG will publicly share a list of volnerabilities and fixes on it's public website [TBD] to inform the Swift Server user community.
+The SSWG will publicly share a list of vulnerabilities and fixes on its public website [TBD] to inform the Swift Server user community.
 
-Project authors are also encouraged to make use of their source control system security features (for example: Github's "Security Advisories" and Gitlab's "Confidential Issues") to manage the volnerabilities and inform their users.
+Project authors are also encouraged to make use of their source control system security features (for example: Github's "Security Advisories" and Gitlab's "Confidential Issues") to manage the vulnerabilities and inform their users.
 
 ## Change Management
 

--- a/process/incubation.md
+++ b/process/incubation.md
@@ -133,9 +133,9 @@ Changes to the Swift Server Ecosystem index page will be announced by the SSWG u
 
 ## Security Best Practices
 
-Project authors that discover, or been advised of vulnerabilities in their libraries, must report them to the SSWG within 10d. Graduated libraries are expected to address vulnerabilities within 30d.
+Project authors that discover, or been advised of vulnerabilities in their libraries, must report them to the SSWG within 10d. Graduated libraries are expected to address vulnerabilities within 30d. Reports should be sent to the SSWG using [Swift forums](https://forums.swift.org/c/server/security-updates). 
 
-The SSWG will publicly share a list of vulnerabilities and fixes on its public website [TBD] to inform the Swift Server user community.
+The SSWG will publicly share a list of vulnerabilities and fixes on [Swift forums](https://forums.swift.org/c/server/security-updates) to inform the Swift Server user community. Members are encouraged to subscribe to notifications and adopt fixes as soon as possible.
 
 Project authors are also encouraged to make use of their source control system security features (for example: Github's "Security Advisories" and Gitlab's "Confidential Issues") to manage the vulnerabilities and inform their users.
 

--- a/process/incubation.md
+++ b/process/incubation.md
@@ -1,6 +1,6 @@
 # Swift Server Work Group Incubation Process
 
-version 1.0
+version 1.1
 
 ## Overview
 
@@ -66,9 +66,13 @@ To be accepted at Incubating level, a project must meet the Sandbox level requir
 
 To be accepted at Graduated level, a project must meet the Incubating level criteria plus:
 
-* Adopt all [SSWG best practices](#best-practices), as detailed below.
+* Adopt all [SSWG graduation requirements](#graduation-requirements), as detailed below.
 * Have committers from at least two organizations.
 * Receive a supermajority vote from the SSWG to move to Graduation stage.
+
+## Process Diagram
+
+![process diagram](incubation.png)
 
 ### Ecosystem Index
 
@@ -109,12 +113,13 @@ Changes to the Swift Server Ecosystem index page will be announced by the SSWG u
   * Must be a team of 2+ developers
   * Must be from a team that has more than one public repository (or similar indication of experience)
   * SSWG should have access / authorization to graduated repositories in case of emergency
+  * Adopt the [SSWG Security Best Practices](#security-best-practices))  
 * Licensing
   * Apache 2
 
-## Best Practices
+## Graduation Requirements
 
-* Address security findings, including in dependencies, within 30d
+* [Minimal Requirements](#minimal-requirements)
 * Support new GA versions of Swift within 30d
 * CI setup for two latest Swift.org recommnded versions of Swift
 * CI setup for two latest versions of Swift.org recommnded Linux distributions
@@ -126,9 +131,13 @@ Changes to the Swift Server Ecosystem index page will be announced by the SSWG u
 * Include list of adopters for at least the primary repo ideally laid out in an ADOPTERS.md files or logos on the project website
 * Optionally, have a [Developer Certificate of Origin](https://developercertificate.org) or a [Contributor License Agreement](https://en.wikipedia.org/wiki/Contributor_License_Agreement)
 
-## Process Diagram
+## Security Best Practices
 
-![process diagram](incubation.png)
+Project authors that discover, or been adviced of volnerabilities in their libraries, must report them to the SSWG within 10d. Graduated libraries are expected to address volnerabilities within 30d.
+
+The SSWG will publicly share a list of volnerabilities and fixes on it's public website [TBD] to inform the Swift Server user community.
+
+Project authors are also encouraged to make use of their source control system security features (for example: Github's "Security Advisories" and Gitlab's "Confidential Issues") to manage the volnerabilities and inform their users.
 
 ## Change Management
 

--- a/process/incubation.md
+++ b/process/incubation.md
@@ -133,7 +133,7 @@ Changes to the Swift Server Ecosystem index page will be announced by the SSWG u
 
 ## Security Best Practices
 
-Project authors that discover, or been advised of vulnerabilities in their projects, must report them to the SSWG within 10d. Graduated projects are expected to address vulnerabilities within 30d. Reports should be sent to the SSWG using [Swift forums](https://forums.swift.org/c/server/security-updates).
+Project authors that discover, or have been advised of vulnerabilities in their projects must report them to the SSWG within 10d. Graduated projects are expected to address vulnerabilities within 30d. Reports should be sent to the SSWG using [Swift forums](https://forums.swift.org/c/server/security-updates).
 
 Failure to report or address vulnerabilities may result in the SSWG publishing a security advisory, and could lead to retracting the project's status and listing it under the non-recommended projects list. In some cases, the SSWG may choose to find a technical contributor that can help resolve the security issues to minimize the impact. SSWG actions will be decided on a case by case basis and require a supermajority vote.
 

--- a/process/incubation.md
+++ b/process/incubation.md
@@ -135,7 +135,7 @@ Changes to the Swift Server Ecosystem index page will be announced by the SSWG u
 
 Project authors that discover, or been advised of vulnerabilities in their projects, must report them to the SSWG within 10d. Graduated projects are expected to address vulnerabilities within 30d. Reports should be sent to the SSWG using [Swift forums](https://forums.swift.org/c/server/security-updates).
 
-Failure to report or address vulnerabilities may result in the SSWG publishing a security advisory, and could lead to retracting the project's status and listing it under the non-recommended projects list. In some cases, the SSWG may choose to find a technical contributor that can help resolve the security issues to minimize the impsct on the ecosystem. SSWG actions will be decided on a case by case basis and requuire a supermajority vote.
+Failure to report or address vulnerabilities may result in the SSWG publishing a security advisory, and could lead to retracting the project's status and listing it under the non-recommended projects list. In some cases, the SSWG may choose to find a technical contributor that can help resolve the security issues to minimize the impact. SSWG actions will be decided on a case by case basis and require a supermajority vote.
 
 The SSWG will publicly share a list of vulnerabilities and fixes on [Swift forums](https://forums.swift.org/c/server/security-updates) to inform the Swift Server user community. Members are encouraged to subscribe to notifications and adopt fixes as soon as possible.
 

--- a/process/incubation.md
+++ b/process/incubation.md
@@ -133,7 +133,7 @@ Changes to the Swift Server Ecosystem index page will be announced by the SSWG u
 
 ## Security Best Practices
 
-Project authors that discover, or been advised of vulnerabilities in their libraries, must report them to the SSWG within 10d. Graduated libraries are expected to address vulnerabilities within 30d. Reports should be sent to the SSWG using [Swift forums](https://forums.swift.org/c/server/security-updates). 
+Project authors that discover, or been advised of vulnerabilities in their projects, must report them to the SSWG within 10d. Graduated projects are expected to address vulnerabilities within 30d. Reports should be sent to the SSWG using [Swift forums](https://forums.swift.org/c/server/security-updates). 
 
 The SSWG will publicly share a list of vulnerabilities and fixes on [Swift forums](https://forums.swift.org/c/server/security-updates) to inform the Swift Server user community. Members are encouraged to subscribe to notifications and adopt fixes as soon as possible.
 


### PR DESCRIPTION
motivation: add more explicit requirements around notifying the workgroup of security vulnerabilities so that this information can be shared with the user community

changes:
* add a "Security Best Practices" section 
* rename "best practices" to "graduation requirements"
* move security requirements from "Graduation Requirements" to "Security Best Practices"
* move "Process Diagram" closer to process description
* bump version to 1.1