### PR TITLE
Update incubation guidelines for server relevance

### DIFF
--- a/process/incubation.md
+++ b/process/incubation.md
@@ -18,7 +18,7 @@ Incubation is made of the following stages: **Pitch**, **Proposal**, **Developme
 
 ### Pitch
 
-Pitches are written proposals of new libraries or tools including ideas for new features in existing libraries or tools. They are used to collect feedback from the community and help define the exact scope of a project prior to writing code. Pitches are submitted by creating a new thread in the Swift Server forum area.
+Pitches are an introduction to an idea for a new library or tool. They can also introduce ideas for new features or additions to existing tools. Pitches are used to collect feedback from the community and help define the exact scope of a project prior to writing code. They should also demonstrate how they align with the SSWG's goals to improve Swift on the server. Pitches are submitted by creating a new thread in the Swift Server forum area.
 
 ### Proposal
 
@@ -91,6 +91,7 @@ Changes to the Swift Server Ecosystem index page will be announced by the SSWG u
 ## Minimal Requirements
 
 * General
+  * Has relevance to Swift on the server specifically
   * Publicly accessible source managed by an SCM such as github.com or similar
   * Adopt the [Swift Code of Conduct](https://swift.org/community/#code-of-conduct)
 * Ecosystem

--- a/process/incubation.md
+++ b/process/incubation.md
@@ -18,7 +18,7 @@ Incubation is made of the following stages: **Pitch**, **Proposal**, **Developme
 
 ### Pitch
 
-Pitches are an introduction to an idea for a new library or tool. They can also introduce ideas for new features or additions to existing tools. Pitches are used to collect feedback from the community and help define the exact scope of a project prior to writing code. They should also demonstrate how they align with the SSWG's goals to improve Swift on the server. Pitches are submitted by creating a new thread in the Swift Server forum area.
+Pitches are an introduction to an idea for a new library or tool. They can also introduce ideas for new features or changes to existing tools. Pitches are used to collect feedback from the community and help define the exact scope of a project prior to writing code. They should demonstrate how they align with the SSWG's goals to improve Swift on the server. Pitches are submitted by creating a new thread in the Swift Server forum area.
 
 ### Proposal
 

--- a/process/incubation.md
+++ b/process/incubation.md
@@ -91,7 +91,7 @@ Changes to the Swift Server Ecosystem index page will be announced by the SSWG u
 ## Minimal Requirements
 
 * General
-  * Has relevance to Swift on the server specifically
+  * Has relevance to Swift on Server specifically
   * Publicly accessible source managed by an SCM such as github.com or similar
   * Adopt the [Swift Code of Conduct](https://swift.org/community/#code-of-conduct)
 * Ecosystem


### PR DESCRIPTION
This PR updates the incubation process to be more specific about the SSWG's goals for the package index. The main idea I'm attempting to present here is that packages submitted to the SSWG should demonstrate a meaningful impact for server use cases specifically. The SSWG's package index is not meant to be a general purpose Swift package index. 

The changes I've made here are fairly minimal, but I wanted to start small and see if this seems sufficient. 