### PR TITLE
Add language around default branch name

### DIFF
--- a/process/incubation.md
+++ b/process/incubation.md
@@ -114,7 +114,7 @@ Changes to the Swift Server Ecosystem index page will be announced by the SSWG u
 * General
   * Has relevance to Swift on Server specifically
   * Publicly accessible source managed by an SCM such as github.com or similar
-    * Prefer to use `main` as the default branch name, in line with [Swift itself](https://forums.swift.org/t/moving-default-branch-to-main/38515) and all SSWG-owned repos
+    * Prefer to use `main` as the default branch name, in line with [Swift's guidelines](https://forums.swift.org/t/moving-default-branch-to-main/38515)
   * Adopt the [Swift Code of Conduct](https://swift.org/community/#code-of-conduct)
 * Ecosystem
   * Uses SwiftPM

--- a/process/incubation.md
+++ b/process/incubation.md
@@ -1,6 +1,6 @@
 # Swift Server Work Group Incubation Process
 
-version 1.3.0
+version 1.4.0
 
 ## Overview
 
@@ -115,6 +115,7 @@ Changes to the Swift Server Ecosystem index page will be announced by the SSWG u
   * Has relevance to Swift on Server specifically
   * Publicly accessible source managed by an SCM such as github.com or similar
   * Adopt the [Swift Code of Conduct](https://swift.org/community/#code-of-conduct)
+  * Prefer to use `main` as the default branch name, in line with [Swift itself](https://forums.swift.org/t/moving-default-branch-to-main/38515) and all SSWG-owned repos
 * Ecosystem
   * Uses SwiftPM
   * Integrated with critical SSWG ecosystem building blocks, e.g., Logging and Metrics APIs, SwiftNIO for IO
@@ -124,7 +125,7 @@ Changes to the Swift Server Ecosystem index page will be announced by the SSWG u
   * Blocking code should be wrapped in NonBlockingIOPool (like Vapor's SQLite package)
 * Testing, CI and Release
   * Have unit tests for Linux
-  * CI setup, including testing PRs and the master branch
+  * CI setup, including testing PRs and the main branch
   * Follow semantic versioning
 * Conventions and Style
   * Error handling

--- a/process/incubation.md
+++ b/process/incubation.md
@@ -114,8 +114,8 @@ Changes to the Swift Server Ecosystem index page will be announced by the SSWG u
 * General
   * Has relevance to Swift on Server specifically
   * Publicly accessible source managed by an SCM such as github.com or similar
+    * Prefer to use `main` as the default branch name, in line with [Swift itself](https://forums.swift.org/t/moving-default-branch-to-main/38515) and all SSWG-owned repos
   * Adopt the [Swift Code of Conduct](https://swift.org/community/#code-of-conduct)
-  * Prefer to use `main` as the default branch name, in line with [Swift itself](https://forums.swift.org/t/moving-default-branch-to-main/38515) and all SSWG-owned repos
 * Ecosystem
   * Uses SwiftPM
   * Integrated with critical SSWG ecosystem building blocks, e.g., Logging and Metrics APIs, SwiftNIO for IO


### PR DESCRIPTION
Open to any suggestions for wording improvements. Since this relates to version control specifically it seemed like a good fit as a sub-bullet but happy to move it to another section as well.