### PR TITLE
update process per SSWG 9/16 meeting

### DIFF
--- a/process/incubation.md
+++ b/process/incubation.md
@@ -51,7 +51,7 @@ Proposals are submitted to the SSWG by creating a PR that adds the proposal docu
 * Social media accounts (optional)
 * Community size and any existing sponsorship (optional)
 
-Once a proposal PR is submitted, the SSWG will assign a review manager during it's bi-weekely meeting.
+Once a proposal PR is submitted, the SSWG will assign a review manager during it's bi-weekly meeting.
 The review manager responsibilities include:
 
 * Review the PR
@@ -125,7 +125,7 @@ It is recommended for projects that have been accepted to any of the maturity le
 [![sswg:incubating|104x20](https://img.shields.io/badge/sswg-incubating-blue.svg)](https://github.com/swift-server/sswg/blob/master/process/incubation.md#incubating-level)
 [![sswg:graduated|104x20](https://img.shields.io/badge/sswg-graduated-green.svg)](https://github.com/swift-server/sswg/blob/master/process/incubation.md#graduated-level)
 
-The SSWG will meet every 6 month to review all projects, and it reserves the right to demote, archive, or remove projects that no longer fulfill minimal requirements.
+The SSWG will meet every 6 months to review all projects, and it reserves the right to demote, archive, or remove projects that no longer fulfill minimal requirements.
 For example, a Graduated project that no longer receives regular updates or fails to address security concerns in timely fashion. Similarly, the SSWG reserves the right to remove or archive Pitches and Proposals that no longer receive updates.
 
 Changes to the Swift Server Ecosystem index page will be announced by the SSWG using the Swift Server forums.
@@ -149,10 +149,10 @@ Changes to the Swift Server Ecosystem index page will be announced by the SSWG u
   * CI setup, including testing PRs and the main branch
   * Follow semantic versioning, with at least one published pre-release (e.g. 0.1.0, 1.0.0-beta.1) or release (e.g. 1.0.0)
 * Licensing
-  * Apache 2, MIT or BSD (Apache 2 recommended)
+  * Apache 2, MIT, or BSD (Apache 2 recommended)
 * Conventions and Style
   * Adopt [Swift API Design Guidelines](https://swift.org/documentation/api-design-guidelines/)
-  * Follow [SSWG Technical Best Practices](#technical-best-practices)) when applicable.
+  * Follow [SSWG Technical Best Practices](#technical-best-practices) when applicable.
   * Prefer to adopt code formatting tools and integrate them into the CI
 
 ## Graduation Requirements
@@ -187,7 +187,7 @@ Project authors are also encouraged to make use of their source control system s
 * Concurrency / IO
   * Packages should be non-blocking (w/ async API) unless not possible (blocking C libs, etc)
   * There should be as little (preferably no) wrapping of NIO as possible. Exposing NIO types directly will go a long way for making packages compatible.
-  * Blocking code should be wrapped in NonBlockingIOPool (like Vapor's SQLite package)  
+  * Blocking code should be wrapped in [NIOThreadPool](https://apple.github.io/swift-nio/docs/current/NIO/Classes/NIOThreadPool.html) (like Vapor's SQLite package)  
 * Uses force unwraps and force tries only as preconditions, ie. conditions that the programmer regards as impossible or programmer error. All force tries/unwraps should come with a comment stating the reasons
 * Does not use `*Unsafe*` unless interfacing with C
   * Exceptions to uses of `*Unsafe*` constructs are acceptable when appropriately documented why they are absolutely necessary.

--- a/process/incubation.md
+++ b/process/incubation.md
@@ -1,6 +1,6 @@
 # Swift Server Work Group Incubation Process
 
-version 1.4.0
+version 1.5.0
 
 ## Overview
 
@@ -10,19 +10,29 @@ The difference between the SSWG and the Swift Evolution process is that server-o
 
 The teams at Apple and Vapor have engineers that will actively participate in the development of such libraries and tools, and we would love to see the community joining in this effort. To that end, the work group defined and launches an incubation process where *anyone* can pitch, propose, develop, and contribute to such libraries and tools.
 
-The incubation process is designed to help nurture and mature projects ensuring standardization, quality, and longevity. It also seeks to increase the visibility of ideas, experiments, or other early work that can add value to the SSWG mission. The following document details this incubation process. The SSWG [steering group](https://swift.org/server/) has a similar role to the Swift Core Team and will make the final decision on moving pitches/proposals through the incubation process based on the feedback of the community. Just like for Swift Evolution, pitches and proposals can be made by anyone, being part of the SSWG steering group is absolutely not a requirement.
+The incubation process is designed to help nurture and mature projects ensuring standardization, quality, and longevity. It also seeks to increase the visibility of ideas, experiments, or other early work that can add value to the SSWG mission.
+The following document details this incubation process.
+The SSWG [steering group](https://swift.org/server/) has a similar role to the Swift Core Team and will make the final decision on moving pitches/proposals through the incubation process based on the feedback of the community.
+Just like for Swift Evolution, pitches and proposals can be made by anyone, being part of the SSWG steering group is absolutely not a requirement.
 
 ## Process
 
-Incubation is made of the following stages: **Pitch**, **Proposal**, **Development**, and **Recommendation**. The Development stage is where the majority of incubation take place. The SSWG will maintain a public "Swift Server Ecosystem" index page that will list all recommended tools and libraries as well as projects that are part of the incubation process and their respective incubation level.
+Incubation is made of the following stages: **Pitch**, **Proposal**, **Development**, and **Recommendation**.
+The Development stage is where the majority of incubation take place.
+The SSWG will maintain a public "Swift Server Ecosystem" index page that will list all recommended tools and libraries as well as projects that are part of the incubation process and their respective incubation level.
 
 ### Pitch
 
-Pitches are an introduction to an idea for a new library or tool. They can also introduce ideas for new features or changes to existing tools. Pitches are used to collect feedback from the community and help define the exact scope of a project prior to writing code. They should demonstrate how they align with the SSWG's goals to improve Swift on the server. Pitches are submitted by creating a new thread in the Swift Server forum area.
+Pitches are an introduction to an idea for a new library or tool.
+They can also introduce ideas for new features or changes to existing tools.
+Pitches are used to collect feedback from the community and help define the exact scope of a project prior to writing code.
+They should demonstrate how they align with the SSWG's goals to improve Swift on the server.
+Pitches are submitted by creating a new thread in the Swift Server forum area.
 
 ### Proposal
 
-For a pitch to be moved into the Proposal stage, it must be endorsed by at least two members of the SSWG. The scope of the proposed code needs to closely align with the endorsed Pitch and it is subject to review based on the SSWG graduation criteria defined below. 
+For a pitch to be moved into the Proposal stage, it must be endorsed by at least two members of the SSWG.
+The scope of the proposed code needs to closely align with the endorsed Pitch and it is subject to review based on the SSWG graduation criteria defined below.
 
 Proposals are submitted to the SSWG by creating a PR that adds the proposal document to the [proposal directory](https://github.com/swift-server/sswg/tree/master/proposals). Proposals follow [a template](https://github.com/swift-server/sswg/blob/master/proposals/0000-template.md) and include the following information:
 
@@ -39,12 +49,13 @@ Proposals are submitted to the SSWG by creating a PR that adds the proposal docu
 * Communication channels (slack, irc, mailing lists)
 * Website (optional)
 * Social media accounts (optional)
-* Community size and any existing sponsorship
+* Community size and any existing sponsorship (optional)
 
-Once a propsal PR is submitted, the SSWG will assign a review manager during it's bi-weekely meeting. The review manager responsibilities include:
+Once a proposal PR is submitted, the SSWG will assign a review manager during it's bi-weekely meeting.
+The review manager responsibilities include:
 
-* Review the PR 
-  * Vaidate structure and language.
+* Review the PR
+  * Validate structure and language.
   * Make sure the implementation is in place.
 * Update the PR
   * Assign a number.
@@ -64,30 +75,37 @@ After the vote, the review manager will:
 
 ### Graduation Criteria
 
-Every SSWG project has an associated maturity level: **Sandbox**, **Incubating**, or **Graduated**. Proposals should state their preferred initial maturity level, and the SSWG will take a vote to decide on the actual level.
+Every SSWG project has an associated maturity level: **Sandbox**, **Incubating**, or **Graduated**.
+Proposals should state their preferred initial maturity level, and the SSWG will take a vote to decide on the actual level.
 
-A **supermajority** (two-thirds) is required for a project to be accepted as Incubating or Graduated. If there is not a supermajority of votes to enter at the Graduated level, then the votes toward Graduated are recounted as votes to enter at the Incubating level. If there is not a supermajority of votes to enter at the Incubating level, then all votes are recounted as **sponsorship** to enter at the Sandbox level. If there are not at least two sponsors, the Proposal is rejected.
+A **supermajority** (two-thirds) is required for a project to be accepted as Incubating or Graduated.
+If there is not a supermajority of votes to enter at the Graduated level, then the votes toward Graduated are recounted as votes to enter at the Incubating level.
+If there is not a supermajority of votes to enter at the Incubating level, then all votes are recounted as **sponsorship** to enter at the Sandbox level.
+If there are not at least two sponsors, the Proposal is rejected.
 
 #### Sandbox Level
 
 To be accepted at the Sandbox level, a project must meet the [SSWG minimal requirements](#minimal-requirements) detailed below and be endorsed by at least two SSWG sponsors.
 
-Early adopters should treat early stage projects with extra care. While Sandbox projects are safe to try out, it is expected that some projects may fail and never move to the next maturity level. There is no guarantee of production readiness, users, or professional level support. As such, users must exercise their own judgment.
+Early adopters should treat early stage projects with extra care.
+While Sandbox projects are safe to try out, it is expected that some projects may fail and never move to the next maturity level.
+There is no guarantee of production readiness, users, or professional level support.
+As such, users must exercise their own judgment.
 
 #### Incubating Level
 
 To be accepted at Incubating level, a project must meet the Sandbox level requirements plus:
 
-* Document that it is being used successfully in production by at least three independent end users which, in the SSWG judgement, are of adequate quality and scope.
-* Have a healthy number of committers. In this context, a committer is an individual who was given write access to the codebase, and has been actively reviewing and managing contributions from the rest of the project's community. 
-* Demonstrate a substantial ongoing flow of commits and merged contributions.
+* Document that it is being used successfully in production by at least two independent end users which, in the SSWG judgement, are of adequate quality and scope.
+* Must have 2+ committers. In this context, a committer is an individual who was given write access to the codebase, and has been actively reviewing and managing contributions from the rest of the project's community.
+* Demonstrate an ongoing flow of commits and merged contributions, or issues addressed in timely manner, or similar indication of activity.
 * Receive a supermajority vote from the SSWG to move to Incubation stage.
 
 #### Graduated Level
 
-To be accepted at Graduated level, a project must meet the Incubating level criteria plus:
+To be accepted at Graduated level, a project must meet the [SSWG graduation requirements](#graduation-requirements) detailed below, plus:
 
-* Adopt all [SSWG graduation requirements](#graduation-requirements), as detailed below.
+* Document that it is being used successfully in production by at least three independent end users which, in the SSWG judgement, are of adequate quality and scope.
 * Have committers, as defined above, from at least two organizations.
 * Receive a supermajority vote from the SSWG to move to Graduation stage.
 
@@ -97,7 +115,9 @@ To be accepted at Graduated level, a project must meet the Incubating level crit
 
 ### Ecosystem Index
 
-All projects and their respective levels will be listed on the [Swift Server Ecosystem Index](https://swift.org/server/#projects). In cases where more than one project solves a particular problem (e.g., two similar database drivers), they will be ordered by popularity. The SSWG reserves the right to define a singular solution for critical building blocks, such as Logging or Metrics APIs, where consistency across the ecosystem is of a critical nature.
+All projects and their respective levels will be listed on the [Swift Server Ecosystem Index](https://swift.org/server/#projects).
+In cases where more than one project solves a particular problem (e.g., two similar database drivers), they will be ordered by popularity.
+The SSWG reserves the right to define a singular solution for critical building blocks, such as Logging or Metrics APIs, where consistency across the ecosystem is of a critical nature.
 
 It is recommended for projects that have been accepted to any of the maturity levels to list the maturity level in their project's README with the appropriate badge as defined:
 
@@ -105,7 +125,8 @@ It is recommended for projects that have been accepted to any of the maturity le
 [![sswg:incubating|104x20](https://img.shields.io/badge/sswg-incubating-blue.svg)](https://github.com/swift-server/sswg/blob/master/process/incubation.md#incubating-level)
 [![sswg:graduated|104x20](https://img.shields.io/badge/sswg-graduated-green.svg)](https://github.com/swift-server/sswg/blob/master/process/incubation.md#graduated-level)
 
-The SSWG will meet every 6 month to review all projects, and it reserves the right to demote, archive, or remove projects that no longer fulfill minimal requirements. For example, a Graduated project that no longer receives regular updates or fails to address security concerns in timely fashion. Similarly, the SSWG reserves the right to remove or archive Pitches and Proposals that no longer receive updates.
+The SSWG will meet every 6 month to review all projects, and it reserves the right to demote, archive, or remove projects that no longer fulfill minimal requirements.
+For example, a Graduated project that no longer receives regular updates or fails to address security concerns in timely fashion. Similarly, the SSWG reserves the right to remove or archive Pitches and Proposals that no longer receive updates.
 
 Changes to the Swift Server Ecosystem index page will be announced by the SSWG using the Swift Server forums.
 
@@ -119,40 +140,33 @@ Changes to the Swift Server Ecosystem index page will be announced by the SSWG u
 * Ecosystem
   * Uses SwiftPM
   * Integrated with critical SSWG ecosystem building blocks, e.g., Logging and Metrics APIs, SwiftNIO for IO
-* Concurrency / IO
-  * Packages should be non-blocking (w/ async API) unless not possible (blocking C libs, etc)
-  * There should be as little (preferably no) wrapping of NIO as possible. Exposing NIO types directly will go a long way for making packages compatible.
-  * Blocking code should be wrapped in NonBlockingIOPool (like Vapor's SQLite package)
+* Longevity
+  * Must be from a team that has more than one public repository (or similar indication of experience)
+  * SSWG should have access / authorization to graduated repositories in case of emergency
+  * Adopt the [SSWG Security Best Practices](#security-best-practices))    
 * Testing, CI and Release
   * Have unit tests for Linux
   * CI setup, including testing PRs and the main branch
-  * Follow semantic versioning
-* Conventions and Style
-  * Error handling
-  * Follow Swift Code style guidelines
-  * Uses force unwraps and force tries only as preconditions, ie. conditions that the programmer regards as impossible or programmer error. All force tries/unwraps should come with a comment stating the reasons
-  * Prefer native Swift over C wrapping, where appropriate
-  * Does not use `*Unsafe*` unless interfacing with C
-    * Exceptions to uses of `*Unsafe*` constructs are acceptable when appropriately documented why they are absolutely necessary.
-    * When `*Unsafe*` is used in this manner, its is expected to be accompanied by enhancement request tickets for the root cause in Swift, SwiftNIO, or a different offending library.
-* Longevity
-  * Must be a team of 2+ developers
-  * Must be from a team that has more than one public repository (or similar indication of experience)
-  * SSWG should have access / authorization to graduated repositories in case of emergency
-  * Adopt the [SSWG Security Best Practices](#security-best-practices))  
+  * Follow semantic versioning, with at least one published pre-release (e.g. 0.1.0, 1.0.0-beta.1) or release (e.g. 1.0.0)
 * Licensing
-  * Apache 2
+  * Apache 2, MIT or BSD (Apache 2 recommended)
+* Conventions and Style
+  * Adopt [Swift API Design Guidelines](https://swift.org/documentation/api-design-guidelines/)
+  * Follow [SSWG Technical Best Practices](#technical-best-practices)) when applicable.
+  * Prefer to adopt code formatting tools and integrate them into the CI
 
 ## Graduation Requirements
 
 * [Minimal Requirements](#minimal-requirements)
+* Have stable API (no pending/planned breaking API changes), with at least one published major release (e.g. 1.0.0)
 * Support new GA versions of Swift within 30d
-* CI setup for two latest Swift.org recommnded versions of Swift
-* CI setup for two latest versions of Swift.org recommnded Linux distributions
+* CI setup for two latest Swift.org recommended versions of Swift
+* CI setup for at least one of Swift.org recommended Linux distributions
+* CI setup for each platform supported by the library or tool
 * Unit tests for both macOS and Linux
-* Use official docker (when appropriate)
+* Use Swift.org docker images, when appropriate
 * Documented release methodology
-* All packages should always work with at least the latest released version of Swift
+* Documented support strategy for at least one previous major version.
 * Explicitly define a project governance and committer process, ideally laid out in a GOVERNANCE.md file and OWNERS.md files respectively
 * Include list of adopters for at least the primary repo ideally laid out in an ADOPTERS.md files or logos on the project website
 * Optionally, have a [Developer Certificate of Origin](https://developercertificate.org) or a [Contributor License Agreement](https://en.wikipedia.org/wiki/Contributor_License_Agreement)
@@ -166,6 +180,20 @@ Failure to report or address vulnerabilities may result in the SSWG publishing a
 The SSWG will publicly share a list of vulnerabilities and fixes on [Swift forums](https://forums.swift.org/c/server/security-updates) to inform the Swift Server user community. Members are encouraged to subscribe to notifications and adopt fixes as soon as possible.
 
 Project authors are also encouraged to make use of their source control system security features (for example: Github's "Security Advisories" and Gitlab's "Confidential Issues") to manage the vulnerabilities and inform their users.
+
+## Technical Best Practices
+
+* Prefer native Swift over C wrapping, where appropriate
+* Concurrency / IO
+  * Packages should be non-blocking (w/ async API) unless not possible (blocking C libs, etc)
+  * There should be as little (preferably no) wrapping of NIO as possible. Exposing NIO types directly will go a long way for making packages compatible.
+  * Blocking code should be wrapped in NonBlockingIOPool (like Vapor's SQLite package)  
+* Uses force unwraps and force tries only as preconditions, ie. conditions that the programmer regards as impossible or programmer error. All force tries/unwraps should come with a comment stating the reasons
+* Does not use `*Unsafe*` unless interfacing with C
+  * Exceptions to uses of `*Unsafe*` constructs are acceptable when appropriately documented why they are absolutely necessary.
+  * When `*Unsafe*` is used in this manner, its is expected to be accompanied by enhancement request tickets for the root cause in Swift, SwiftNIO, or a different offending library.
+* Avoid using `fatalError` to deal with error cases, design APIs that `throws` or return `Result` instead.
+
 
 ## Change Management
 


### PR DESCRIPTION
motivation: the SSWG reviewed the incubation process on 9/16 and suggested changes

changes:

Sandbox
-------
* Single developer okay
* License: MIT and BSD also okay

Incubating
----------
* Min 2 developers
* Flow of commits or issues addressed -> since mature projects issues addressed could be better indications

Graduated
---------
* Require a stable API -> No major API changes planned in the foreseeable future
* Define how new major API should be introduced, and what support is expected for older major versions (1 back? More?)
* Add link to Swift code style guide
* Encourage the use of formatting tooling + add link to such tools
* Remove Unsafe / make it an example
* CI setup for every platform decanted as supported
    * At least one Linux distro
* Remove redundant swift versions support line item