### PR TITLE
Update members list

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,9 @@ The current Swift Server work group consists of the following people:
 * Tanner Nelson ([@tanner0101](https://forums.swift.org/u/tanner0101), Vapor)
 * Johannes Weiss ([@johannesweiss](https://forums.swift.org/u/johannesweiss), Apple)
 * Tom Doron ([@tomerd](https://forums.swift.org/u/tomerd), Apple)
+* Kaitlin Mahar ([@kmahar](https://github.com/kmahar), MongoDB)
+* Simon Pilkington ([@tachyonics](https://github.com/tachyonics), Amazon)
+* Todd Varland ([@toddvarland](https://github.com/toddvarland), Amazon)
 
 ## Communication
 


### PR DESCRIPTION
https://forums.swift.org/t/july-29th-2020-special-update/38869, and https://swift.org/server/ contain accurate members lists.